### PR TITLE
add proxy detection to gather

### DIFF
--- a/pkg/cli.go
+++ b/pkg/cli.go
@@ -154,6 +154,7 @@ For more information, check OADP must-gather documentation: https://docs.redhat.
 			nodeList := &corev1.NodeList{}
 			clusterServiceVersionList := &operatorsv1alpha1.ClusterServiceVersionList{}
 			subscriptionList := &operatorsv1alpha1.SubscriptionList{}
+			proxyList := &openshiftconfigv1.ProxyList{}
 
 			dataProtectionApplicationList := &oadpv1alpha1.DataProtectionApplicationList{}
 			dataProtectionTestList := &oadpv1alpha1.DataProtectionTestList{}
@@ -185,6 +186,7 @@ For more information, check OADP must-gather documentation: https://docs.redhat.
 				nodeList,
 				clusterServiceVersionList,
 				subscriptionList,
+				proxyList,
 
 				dataProtectionApplicationList,
 				dataProtectionTestList,
@@ -314,6 +316,7 @@ For more information, check OADP must-gather documentation: https://docs.redhat.
 			// https://github.com/konveyor/analyzer-lsp/blob/main/engine/engine.go
 			templates.ReplaceMustGatherVersion(mustGatherVersion)
 			templates.ReplaceClusterInformationSection(outputPath, clusterID, clusterVersion, infrastructureList, nodeList)
+			templates.ReplaceProxiesSection(outputPath, proxyList)
 			templates.ReplaceOADPOperatorInstallationSection(outputPath, importantCSVsByNamespace, importantSubscriptionsByNamespace, foundOADP, foundRelatedProducts, oldOADPError, oadpOperatorsText)
 			templates.ReplaceDataProtectionApplicationsSection(outputPath, dataProtectionApplicationList)
 			templates.ReplaceDataProtectionTestsSection(outputPath, dataProtectionTestList)

--- a/pkg/gvk/gvk.go
+++ b/pkg/gvk/gvk.go
@@ -145,4 +145,9 @@ var (
 		Version: "v1",
 		Kind:    "CSIDriver",
 	}
+	ProxyGVK = schema.GroupVersionKind{
+		Group:   "config.openshift.io",
+		Version: "v1",
+		Kind:    "Proxy",
+	}
 )

--- a/pkg/templates/summary.go
+++ b/pkg/templates/summary.go
@@ -44,6 +44,7 @@ var (
 		"MUST_GATHER_VERSION",
 		"ERRORS",
 		"CLUSTER_ID", "OCP_VERSION", "CLOUD", "ARCH", "CLUSTER_VERSION",
+		"PROXIES",
 		"OADP_VERSIONS",
 		"DATA_PROTECTION_APPLICATIONS",
 		"DATA_PROTECTION_TESTS",
@@ -82,6 +83,7 @@ const summaryTemplate = `# OADP must-gather summary version <<MUST_GATHER_VERSIO
 
 - [Errors](#errors)
 - [Cluster information](#cluster-information)
+- [Proxies](#proxies)
 - [OADP operator installation information](#oadp-operator-installation-information)
     - [DataProtectionApplications (DPAs)](#dataprotectionapplications-dpas)
 	- [DataProtectionTests (DPTs)](#dataprotectiontests-dpts)
@@ -133,6 +135,10 @@ const summaryTemplate = `# OADP must-gather summary version <<MUST_GATHER_VERSIO
 ### DataProtectionTests (DPTs)
 
 <<DATA_PROTECTION_TESTS>>
+
+### Proxies
+
+<<PROXIES>>
 
 ### CloudStorages
 
@@ -1690,6 +1696,7 @@ func ReplaceCustomResourceDefinitionsSection(outputPath string, clusterConfig *r
 		"nonadmindownloadrequests":              gvk.NonAdminDownloadRequestGVK.Group,
 		"clusterserviceversions":                gvk.ClusterServiceVersionGVK.Group,
 		"subscriptions":                         gvk.SubscriptionsGVK.Group,
+		"proxies":                               gvk.ProxyGVK.Group,
 	}
 
 	for crdName, crdGroup := range crds {
@@ -1704,6 +1711,48 @@ func ReplaceCustomResourceDefinitionsSection(outputPath string, clusterConfig *r
 	}
 
 	summaryTemplateReplaces["CUSTOM_RESOURCE_DEFINITION"] += fmt.Sprintf("For more information, check [`%s`](%s)\n\n", crdsPath, crdsPath)
+}
+
+func ReplaceProxiesSection(outputPath string, proxyList *openshiftconfigv1.ProxyList) {
+	if proxyList != nil && len(proxyList.Items) != 0 {
+		list := &corev1.List{}
+		list.GetObjectKind().SetGroupVersionKind(gvk.ListGVK)
+
+		folder := "cluster-scoped-resources/config.openshift.io/proxies"
+		file := folder + "/proxies.yaml"
+
+		summaryTemplateReplaces["PROXIES"] += "| Name | HTTP Proxy | HTTPS Proxy | No Proxy | yaml |\n| --- | --- | --- | --- | --- |\n"
+
+		for _, proxy := range proxyList.Items {
+			proxy.GetObjectKind().SetGroupVersionKind(gvk.ProxyGVK)
+			list.Items = append(list.Items, runtime.RawExtension{Object: &proxy})
+
+			httpProxy := proxy.Spec.HTTPProxy
+			if len(httpProxy) == 0 {
+				httpProxy = "❌ not set"
+			}
+
+			httpsProxy := proxy.Spec.HTTPSProxy
+			if len(httpsProxy) == 0 {
+				httpsProxy = "❌ not set"
+			}
+
+			noProxy := proxy.Spec.NoProxy
+			if len(noProxy) == 0 {
+				noProxy = "❌ not set"
+			}
+
+			link := fmt.Sprintf("[`yaml`](%s)", file)
+			summaryTemplateReplaces["PROXIES"] += fmt.Sprintf(
+				"| %v | %v | %v | %v | %s |\n",
+				proxy.Name, httpProxy, httpsProxy, noProxy, link,
+			)
+		}
+
+		createYAML(outputPath, file, list)
+	} else {
+		summaryTemplateReplaces["PROXIES"] = "❌ No Proxy configuration found in the cluster"
+	}
 }
 
 func createYAML(outputPath string, yamlPath string, obj runtime.Object) string {


### PR DESCRIPTION
### ✅ Changes Made

1. **GVK Definition** (`pkg/gvk/gvk.go`):
   - Added `ProxyGVK` definition for `proxies.config.openshift.io/v1` resources

2. **Resource Collection** (`pkg/cli.go`):
   - Added `proxyList := &openshiftconfigv1.ProxyList{}` variable declaration
   - Added `proxyList` to the `resourcesToGather` slice
   - Added template replacement call: `templates.ReplaceProxiesSection(outputPath, proxyList)`

3. **Template Integration** (`pkg/templates/summary.go`):
   - Added `"PROXIES"` to the `summaryTemplateReplacesKeys` array
   - Added "Proxies" section to the table of contents
   - Added `<<PROXIES>>` placeholder in the template
   - Added `"proxies"` to the CRD collection map
   - Created `ReplaceProxiesSection()` function that:
     - Collects all proxy configurations from the cluster
     - Creates a formatted table with columns: Name, HTTP Proxy, HTTPS Proxy, No Proxy, yaml
     - Saves proxy configurations to `cluster-scoped-resources/config.openshift.io/proxies/proxies.yaml`
     - Handles cases where no proxy configurations are found

### 🎯 Features

- **Comprehensive Collection**: Gathers all instances of `proxies.config.openshift.io` resources
- **Rich Display**: Shows key proxy settings (HTTP proxy, HTTPS proxy, no proxy rules)
- **YAML Export**: Saves full proxy configurations to YAML files for detailed inspection
- **Error Handling**: Gracefully handles clusters without proxy configurations
- **Consistent Format**: Follows the same pattern as other resource collections in the tool

### 📁 Output Structure

When the must-gather runs, proxy configurations will be:
- Listed in the summary report with key details in a table format
- Saved as YAML files in `cluster-scoped-resources/config.openshift.io/proxies/proxies.yaml`
- Linked from the summary for easy access to full configuration details

The implementation is now ready and the tool builds successfully. Users can run the OADP must-gather tool and it will automatically collect all proxy configurations from the OpenShift cluster along with all other OADP-related resources.

@kaovilai please check my ai bot lolz.