### PR TITLE
set skip-tls default to true

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,7 +10,7 @@ import (
 
 func init() {
 	pkg.CLI.Flags().DurationVarP(&pkg.RequestTimeout, "request-timeout", "r", pkg.DefaultRequestTimeout, "Timeout per OADP server request (like collecting logs from a backup)")
-	pkg.CLI.Flags().BoolVarP(&pkg.SkipTLS, "skip-tls", "s", false, "Run OADP server requests with insecure TLS connections (recommended if a custom CA certificate is used) (default false)")
+	pkg.CLI.Flags().BoolVarP(&pkg.SkipTLS, "skip-tls", "s", true, "Run OADP server requests with insecure TLS connections (recommended if a custom CA certificate is used) (default true)")
 	// TODO caCertFile?
 	pkg.CLI.Flags().BoolP("help", "h", false, "Show OADP Must-gather help message.")
 

--- a/pkg/cli.go
+++ b/pkg/cli.go
@@ -52,7 +52,7 @@ For more information, check OADP must-gather documentation: https://docs.redhat.
   # running OADP Must-gather with timeout of 1 minute per OADP server request
   oc adm must-gather --image=%[1]s -- /usr/bin/gather --request-timeout 1m
 
-  # running OADP Must-gather with timeout of 15 seconds per OADP server request and with secure TLS connections
+  # running OADP Must-gather with timeout of 15 seconds per OADP server request and with insecure TLS connections
   oc adm must-gather --image=%[1]s -- /usr/bin/gather --request-timeout 15s`, mustGatherImage),
 		SilenceErrors: true,
 		SilenceUsage:  true,

--- a/pkg/cli.go
+++ b/pkg/cli.go
@@ -46,14 +46,14 @@ var (
 
 For more information, check OADP must-gather documentation: https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/backup_and_restore/oadp-application-backup-and-restore#using-the-must-gather-tool`,
 		Args: cobra.NoArgs,
-		Example: fmt.Sprintf(`  # running OADP Must-gather with default configuration
+		Example: fmt.Sprintf(`  # running OADP Must-gather with default configuration (insecure TLS connections enabled by default)
   oc adm must-gather --image=%[1]s
 
   # running OADP Must-gather with timeout of 1 minute per OADP server request
   oc adm must-gather --image=%[1]s -- /usr/bin/gather --request-timeout 1m
 
-  # running OADP Must-gather with timeout of 15 seconds per OADP server request and with insecure TLS connections
-  oc adm must-gather --image=%[1]s -- /usr/bin/gather --request-timeout 15s --skip-tls`, mustGatherImage),
+  # running OADP Must-gather with timeout of 15 seconds per OADP server request and with secure TLS connections
+  oc adm must-gather --image=%[1]s -- /usr/bin/gather --request-timeout 15s`, mustGatherImage),
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(_ *cobra.Command, _ []string) error {


### PR DESCRIPTION
* users are not reading the instructions to skip-tls
* support /eng ends up w/ must-gather's that do not contain all the required logs

TODO: incorporate auto discovery of certs per bsl
https://github.com/vmware-tanzu/velero/pull/8557