### PR TITLE
update the golang version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/oadp-must-gather
 
-go 1.25.0
-
-toolchain go1.25.8
+go 1.25.8
 
 require (
 	github.com/kubernetes-csi/external-snapshotter/client/v8 v8.0.0


### PR DESCRIPTION
update for cve's


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version from 1.25.0 to 1.25.8
  * Simplified Go module version directives

<!-- end of auto-generated comment: release notes by coderabbit.ai -->