### PR TITLE
add extended bsl info in the summary

### DIFF
--- a/pkg/templates/summary.go
+++ b/pkg/templates/summary.go
@@ -533,7 +533,7 @@ func ReplaceBackupStorageLocationsSection(outputPath string, backupStorageLocati
 			backupStorageLocationsByNamespace[backupStorageLocation.Namespace] = append(backupStorageLocationsByNamespace[backupStorageLocation.Namespace], backupStorageLocation)
 		}
 
-		summaryTemplateReplaces["BACKUP_STORAGE_LOCATIONS"] += "| Namespace | Name | spec.default | status.phase | yaml |\n| --- | --- | --- | --- | --- |\n"
+		summaryTemplateReplaces["BACKUP_STORAGE_LOCATIONS"] += "| Namespace | Name | spec.provider | spec.objectStorage.bucket | spec.objectStorage.prefix | spec.config.s3Url | spec.default | status.phase | yaml |\n| --- | --- | --- | --- | --- | --- | --- | --- | --- |\n"
 		for namespace, backupStorageLocations := range backupStorageLocationsByNamespace {
 			list := &corev1.List{}
 			list.GetObjectKind().SetGroupVersionKind(gvk.ListGVK)
@@ -564,18 +564,71 @@ func ReplaceBackupStorageLocationsSection(outputPath string, backupStorageLocati
 					}
 				}
 
+				s3Url := ""
+				if backupStorageLocation.Spec.Config != nil {
+					s3Url = backupStorageLocation.Spec.Config["s3Url"]
+				}
+
 				link := fmt.Sprintf("[`yaml`](%s)", file)
 				summaryTemplateReplaces["BACKUP_STORAGE_LOCATIONS"] += fmt.Sprintf(
-					"| %v | %v | %t | %v | %s |\n",
-					namespace, backupStorageLocation.Name, backupStorageLocation.Spec.Default, bslStatus, link,
+					"| %v | %v | %v | %v | %v | %v | %t | %v | %s |\n",
+					namespace,
+					backupStorageLocation.Name,
+					backupStorageLocation.Spec.Provider,
+					backupStorageLocation.Spec.ObjectStorage.Bucket,
+					backupStorageLocation.Spec.ObjectStorage.Prefix,
+					s3Url,
+					backupStorageLocation.Spec.Default,
+					bslStatus,
+					link,
 				)
 			}
 
 			createYAML(outputPath, file, list)
 		}
+
+		checkDuplicateBSLTargets(backupStorageLocationList)
 	} else {
 		summaryTemplateReplaces["BACKUP_STORAGE_LOCATIONS"] = "❌ No BackupStorageLocation was found in the cluster"
 		summaryTemplateReplaces["ERRORS"] += "⚠️ No BackupStorageLocation was found in the cluster\n\n"
+	}
+}
+
+func checkDuplicateBSLTargets(backupStorageLocationList *velerov1.BackupStorageLocationList) {
+	type bslTarget struct {
+		provider string
+		bucket   string
+		prefix   string
+		s3Url    string
+	}
+
+	targetToBSLs := map[bslTarget][]string{}
+	for _, bsl := range backupStorageLocationList.Items {
+		s3Url := ""
+		if bsl.Spec.Config != nil {
+			s3Url = bsl.Spec.Config["s3Url"]
+		}
+		key := bslTarget{
+			provider: bsl.Spec.Provider,
+			bucket:   bsl.Spec.ObjectStorage.Bucket,
+			prefix:   bsl.Spec.ObjectStorage.Prefix,
+			s3Url:    s3Url,
+		}
+		targetToBSLs[key] = append(targetToBSLs[key], fmt.Sprintf("%s/%s", bsl.Namespace, bsl.Name))
+	}
+
+	for target, bsls := range targetToBSLs {
+		if len(bsls) > 1 {
+			targetDesc := fmt.Sprintf("provider: %s, bucket: %s, prefix: %s", target.provider, target.bucket, target.prefix)
+			if target.s3Url != "" {
+				targetDesc += fmt.Sprintf(", s3Url: %s", target.s3Url)
+			}
+			summaryTemplateReplaces["ERRORS"] += fmt.Sprintf(
+				"⚠️ Multiple BackupStorageLocations share the same target (%s): **%s** — this is dangerous and likely unsupported\n\n",
+				targetDesc,
+				strings.Join(bsls, "**, **"),
+			)
+		}
 	}
 }
 

--- a/pkg/templates/summary.go
+++ b/pkg/templates/summary.go
@@ -569,14 +569,21 @@ func ReplaceBackupStorageLocationsSection(outputPath string, backupStorageLocati
 					s3Url = backupStorageLocation.Spec.Config["s3Url"]
 				}
 
+				bucket := ""
+				prefix := ""
+				if backupStorageLocation.Spec.ObjectStorage != nil {
+					bucket = backupStorageLocation.Spec.ObjectStorage.Bucket
+					prefix = backupStorageLocation.Spec.ObjectStorage.Prefix
+				}
+
 				link := fmt.Sprintf("[`yaml`](%s)", file)
 				summaryTemplateReplaces["BACKUP_STORAGE_LOCATIONS"] += fmt.Sprintf(
 					"| %v | %v | %v | %v | %v | %v | %t | %v | %s |\n",
 					namespace,
 					backupStorageLocation.Name,
 					backupStorageLocation.Spec.Provider,
-					backupStorageLocation.Spec.ObjectStorage.Bucket,
-					backupStorageLocation.Spec.ObjectStorage.Prefix,
+					bucket,
+					prefix,
 					s3Url,
 					backupStorageLocation.Spec.Default,
 					bslStatus,
@@ -608,10 +615,16 @@ func checkDuplicateBSLTargets(backupStorageLocationList *velerov1.BackupStorageL
 		if bsl.Spec.Config != nil {
 			s3Url = bsl.Spec.Config["s3Url"]
 		}
+		bucket := ""
+		prefix := ""
+		if bsl.Spec.ObjectStorage != nil {
+			bucket = bsl.Spec.ObjectStorage.Bucket
+			prefix = bsl.Spec.ObjectStorage.Prefix
+		}
 		key := bslTarget{
 			provider: bsl.Spec.Provider,
-			bucket:   bsl.Spec.ObjectStorage.Bucket,
-			prefix:   bsl.Spec.ObjectStorage.Prefix,
+			bucket:   bucket,
+			prefix:   prefix,
 			s3Url:    s3Url,
 		}
 		targetToBSLs[key] = append(targetToBSLs[key], fmt.Sprintf("%s/%s", bsl.Namespace, bsl.Name))

--- a/pkg/templates/summary_bsl_test.go
+++ b/pkg/templates/summary_bsl_test.go
@@ -1,0 +1,91 @@
+package templates
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func TestReplaceBackupStorageLocationsSectionFromMustGather(t *testing.T) {
+	mustGatherBase := os.Getenv("MUST_GATHER_BSL_PATH")
+	if mustGatherBase == "" {
+		t.Skip("Set MUST_GATHER_BSL_PATH to a must-gather clusters/<id> directory to run this test")
+	}
+
+	pattern := filepath.Join(mustGatherBase, "namespaces", "*", "velero.io", "backupstoragelocations", "backupstoragelocations.yaml")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob error: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no BSL YAML files found matching %s", pattern)
+	}
+
+	allBSLs := &velerov1.BackupStorageLocationList{}
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("reading %s: %v", f, err)
+		}
+
+		var raw struct {
+			Items []json.RawMessage `json:"items"`
+		}
+		if err := yaml.Unmarshal(data, &raw); err != nil {
+			t.Fatalf("unmarshal list from %s: %v", f, err)
+		}
+
+		for _, item := range raw.Items {
+			var bsl velerov1.BackupStorageLocation
+			if err := json.Unmarshal(item, &bsl); err != nil {
+				t.Fatalf("unmarshal BSL item from %s: %v", f, err)
+			}
+			allBSLs.Items = append(allBSLs.Items, bsl)
+		}
+	}
+
+	t.Logf("Loaded %d BSLs from %d files", len(allBSLs.Items), len(files))
+	for _, bsl := range allBSLs.Items {
+		s3Url := ""
+		if bsl.Spec.Config != nil {
+			s3Url = bsl.Spec.Config["s3Url"]
+		}
+		bucket := ""
+		prefix := ""
+		if bsl.Spec.ObjectStorage != nil {
+			bucket = bsl.Spec.ObjectStorage.Bucket
+			prefix = bsl.Spec.ObjectStorage.Prefix
+		}
+		t.Logf("  %s/%s  provider=%s bucket=%s prefix=%s s3Url=%s",
+			bsl.Namespace, bsl.Name, bsl.Spec.Provider, bucket, prefix, s3Url)
+	}
+
+	for _, key := range summaryTemplateReplacesKeys {
+		summaryTemplateReplaces[key] = ""
+	}
+
+	outputPath := t.TempDir() + "/"
+	ReplaceBackupStorageLocationsSection(outputPath, allBSLs)
+
+	md := "# BSL Summary (test output)\n\n"
+	md += "## Errors\n\n"
+	if errs := summaryTemplateReplaces["ERRORS"]; errs != "" {
+		md += errs
+	} else {
+		md += "No errors\n\n"
+	}
+	md += "## BackupStorageLocations (BSLs)\n\n"
+	md += summaryTemplateReplaces["BACKUP_STORAGE_LOCATIONS"]
+
+	outFile := "/tmp/oadp-bsl-summary.md"
+	if err := os.WriteFile(outFile, []byte(md), 0644); err != nil {
+		t.Fatalf("writing %s: %v", outFile, err)
+	}
+	t.Logf("Markdown written to %s", outFile)
+	fmt.Println(md)
+}


### PR DESCRIPTION
should look like:

# BSL Summary (test output)

## Errors

⚠️ Multiple BackupStorageLocations share the same target (provider: aws, bucket: kopia-csi-pcloud-bucket, prefix: pcloud-a, s3Url: https://s3.eu-de.cloud-object-storage.appdomain.cloud): **oadp-workspace-1/s3-oadp**, **oadp-workspace-2/s3-oadp**, **oadp-workspace-3/s3-oadp**, **openshift-adp/s3-oadp** — this is dangerous and likely unsupported

## BackupStorageLocations (BSLs)

| Namespace | Name | spec.provider | spec.objectStorage.bucket | spec.objectStorage.prefix | spec.config.s3Url | spec.default | status.phase | yaml |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| oadp-workspace-1 | s3-oadp | aws | kopia-csi-pcloud-bucket | pcloud-a | https://s3.eu-de.cloud-object-storage.appdomain.cloud | true | ✅ status phase Available | [`yaml`](namespaces/oadp-workspace-1/velero.io/backupstoragelocations/backupstoragelocations.yaml) |
| oadp-workspace-2 | s3-oadp | aws | kopia-csi-pcloud-bucket | pcloud-a | https://s3.eu-de.cloud-object-storage.appdomain.cloud | true | ✅ status phase Available | [`yaml`](namespaces/oadp-workspace-2/velero.io/backupstoragelocations/backupstoragelocations.yaml) |
| oadp-workspace-3 | s3-oadp | aws | kopia-csi-pcloud-bucket | pcloud-a | https://s3.eu-de.cloud-object-storage.appdomain.cloud | true | ✅ status phase Available | [`yaml`](namespaces/oadp-workspace-3/velero.io/backupstoragelocations/backupstoragelocations.yaml) |
| openshift-adp | s3-oadp | aws | kopia-csi-pcloud-bucket | pcloud-a | https://s3.eu-de.cloud-object-storage.appdomain.cloud | true | ✅ status phase Available | [`yaml`](namespaces/openshift-adp/velero.io/backupstoragelocations/backupstoragelocations.yaml) |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced the BackupStorageLocations section in the generated Markdown summary with additional details: provider, bucket, prefix, and S3 URL.
  * Added detection and warnings for duplicate BackupStorageLocation targets that share the same underlying storage destination.  
* **Tests**
  * Added coverage to validate BackupStorageLocations summary generation using files from a must-gather directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->