### PR TITLE
remove the oc binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+must-gather

--- a/Dockerfile.oadp
+++ b/Dockerfile.oadp
@@ -1,9 +1,5 @@
 # upstream src https://github.com/openshift/oadp-must-gather/blob/oadp-dev/Dockerfile
 
-# oc
-#@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli-rhel9:v4.19)
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-cli-rhel9:v4.19 AS ose-cli
-
 #@follow_tag(registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25)
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
 
@@ -57,7 +53,6 @@ RUN microdnf -y install openssl rsync tar gzip && microdnf -y reinstall tzdata &
 
 COPY --from=builder /workspace/velero/bin/velero /usr/bin/velero
 COPY --from=builder /workspace/restic/bin/restic /usr/bin/restic
-COPY --from=ose-cli /usr/bin/oc /usr/bin/oc
 COPY --from=builder /workspace/kopia/kopia /usr/bin/kopia
 COPY --from=builder /workspace/gather /usr/bin/gather
 COPY --from=builder /workspace/deprecated/gather_* /usr/bin/

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,6 +1,3 @@
-# oc
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-cli-rhel9:v4.21 AS ose-cli
-
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
 
 COPY . /workspace
@@ -52,7 +49,6 @@ RUN dnf -y install openssl rsync tar gzip && dnf -y reinstall tzdata && dnf -y c
 
 COPY --from=builder /workspace/velero/bin/velero /usr/bin/velero
 COPY --from=builder /workspace/restic/bin/restic /usr/bin/restic
-COPY --from=ose-cli /usr/bin/oc /usr/bin/oc
 COPY --from=builder /workspace/kopia/kopia /usr/bin/kopia
 COPY --from=builder /workspace/gather /usr/bin/gather
 COPY --from=builder /workspace/deprecated/gather_* /usr/bin/


### PR DESCRIPTION
TOO MANY CVE's

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated repository ignore rules to exclude generated `must-gather` content.
  * Streamlined container image builds so the final images no longer include the OpenShift CLI binary.
  * Preserved the existing packaging of Velero, Restic, Kopia, and gather artifacts in the built images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->