### PR TITLE
remove oc cli from konflux build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+must-gather

--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,6 +1,3 @@
-# oc
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-cli-rhel9:v4.19 AS ose-cli
-
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
 
 COPY . /workspace
@@ -52,7 +49,6 @@ RUN dnf -y install openssl rsync tar gzip && dnf -y reinstall tzdata && dnf -y c
 
 COPY --from=builder /workspace/velero/bin/velero /usr/bin/velero
 COPY --from=builder /workspace/restic/bin/restic /usr/bin/restic
-COPY --from=ose-cli /usr/bin/oc /usr/bin/oc
 COPY --from=builder /workspace/kopia/kopia /usr/bin/kopia
 COPY --from=builder /workspace/gather /usr/bin/gather
 COPY --from=builder /workspace/deprecated/gather_* /usr/bin/


### PR DESCRIPTION
TOO MANY CVE's

Cherry-pick of #137 to oadp-1.5.

Removes the `ose-cli` build stage and `COPY --from=ose-cli /usr/bin/oc /usr/bin/oc` from `konflux.Dockerfile`, and adds a `.gitignore` to exclude generated `must-gather` content.

Made with [Cursor](https://cursor.com)