### PR TITLE
Gather PVC/PV/Namespace(SCC) data for Backup/Restore namespaces

### DIFF
--- a/pkg/cli.go
+++ b/pkg/cli.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strconv"
@@ -295,12 +296,50 @@ For more information, check OADP must-gather documentation: https://docs.redhat.
 				}
 			}
 
+			// find application namespaces referenced by Backups/Restores, so their
+			// PVC/PV/Namespace(SCC)/pod data can be inspected too (helps diagnose
+			// restore permission/ownership bugs)
+			workloadNamespaces := map[string][]string{}
+			for _, backup := range backupList.Items {
+				namespaces, err := gather.BackupWorkloadNamespaces(context.Background(), clusterClient, backup, RequestTimeout, SkipTLS)
+				if err != nil {
+					// do not print err: it may embed the backup storage location's
+					// raw HTTP response body (endpoint/bucket details)
+					fmt.Printf("could not determine workload namespaces for backup %s/%s\n", backup.Namespace, backup.Name)
+					continue
+				}
+				for _, namespace := range namespaces {
+					workloadNamespaces[namespace] = append(workloadNamespaces[namespace], fmt.Sprintf("Backup/%s/%s", backup.Namespace, backup.Name))
+				}
+			}
+			for _, restore := range restoreList.Items {
+				namespaces, err := gather.RestoreWorkloadNamespaces(context.Background(), clusterClient, restore, RequestTimeout, SkipTLS)
+				if err != nil {
+					// do not print err: it may embed the backup storage location's
+					// raw HTTP response body (endpoint/bucket details)
+					fmt.Printf("could not determine workload namespaces for restore %s/%s\n", restore.Namespace, restore.Name)
+					continue
+				}
+				for _, namespace := range namespaces {
+					workloadNamespaces[namespace] = append(workloadNamespaces[namespace], fmt.Sprintf("Restore/%s/%s", restore.Namespace, restore.Name))
+				}
+			}
+
 			// oc adm inspect --dest-dir must-gather/clusters/${clusterID} ns/${ns}
-			if len(importantCSVsByNamespace) != 0 {
+			if len(importantCSVsByNamespace) != 0 || len(workloadNamespaces) != 0 {
 				ocAdmInspect := ocadminspect.NewInspectOptions(genericiooptions.NewTestIOStreamsDiscard())
 				ocAdmInspect.DestDir = outputPath
 				ocAdmInspectNamespaces := []string{}
+				seenNamespaces := map[string]bool{}
 				for namespace := range importantCSVsByNamespace {
+					seenNamespaces[namespace] = true
+					ocAdmInspectNamespaces = append(ocAdmInspectNamespaces, "ns/"+namespace)
+				}
+				for namespace := range workloadNamespaces {
+					if seenNamespaces[namespace] {
+						continue
+					}
+					seenNamespaces[namespace] = true
 					ocAdmInspectNamespaces = append(ocAdmInspectNamespaces, "ns/"+namespace)
 				}
 
@@ -333,6 +372,7 @@ For more information, check OADP must-gather documentation: https://docs.redhat.
 			// this creates DownloadRequests CRs
 			templates.ReplaceBackupsSection(outputPath, backupList, clusterClient, deleteBackupRequestList, podVolumeBackupList, RequestTimeout, SkipTLS)
 			templates.ReplaceRestoresSection(outputPath, restoreList, clusterClient, podVolumeRestoreList, RequestTimeout, SkipTLS)
+			templates.ReplaceWorkloadNamespacesSection(workloadNamespaces)
 
 			downloadRequestList := &velerov1.DownloadRequestList{}
 			err = gather.AllResources(clusterClient, downloadRequestList)

--- a/pkg/gather/namespaces.go
+++ b/pkg/gather/namespaces.go
@@ -1,0 +1,120 @@
+package gather
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/cmd/util/downloadrequest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// isExplicitNamespaceList reports whether included unambiguously names the exact set
+// of namespaces to inspect, with no further resolution needed.
+//
+// It's false whenever the namespace set can only be known by asking what Velero
+// actually did: included is empty (defaults to "all namespaces"); included is the
+// literal "*"; excluded is non-empty (Velero subtracts it from included, so included
+// alone overstates the set); or any entry contains a glob metacharacter (Velero's
+// pkg/util/wildcard expands "*", "?", "[...]" patterns against the live namespace list
+// at backup/restore time — see wildcard.containsWildcardPattern upstream). In all of
+// those cases the caller must fall back to the actual BackupResourceList/
+// RestoreResourceList contents instead of trusting the spec field literally.
+//
+// TODO(velero-io/velero#9772): if namespace selection by ConfigMap-based label
+// selector (independent of IncludedNamespaces) lands, a Backup could still leave
+// IncludedNamespaces empty while relying on that mechanism — already covered here
+// since an empty included falls through to the resourceList fallback.
+func isExplicitNamespaceList(included, excluded []string) bool {
+	if len(included) == 0 || len(excluded) != 0 {
+		return false
+	}
+	for _, namespace := range included {
+		if namespace == "*" || strings.ContainsAny(namespace, "*?[") {
+			return false
+		}
+	}
+	return true
+}
+
+// namespacesFromResourceList extracts the distinct set of namespaces referenced by a
+// Velero Backup/Restore resource list (as returned by the BackupResourceList/
+// RestoreResourceList download targets). Each map value is a list of entries shaped
+// either "namespace/name" (namespaced resource) or "name" (cluster-scoped resource,
+// skipped here since it has no namespace).
+func namespacesFromResourceList(resourceList map[string][]string) []string {
+	seen := map[string]struct{}{}
+	for _, entries := range resourceList {
+		for _, entry := range entries {
+			namespace, _, found := strings.Cut(entry, "/")
+			if !found {
+				continue
+			}
+			seen[namespace] = struct{}{}
+		}
+	}
+
+	namespaces := make([]string, 0, len(seen))
+	for namespace := range seen {
+		namespaces = append(namespaces, namespace)
+	}
+	sort.Strings(namespaces)
+	return namespaces
+}
+
+// BackupWorkloadNamespaces returns the application namespaces a Backup captures data
+// from: backup.Spec.IncludedNamespaces when it unambiguously names them (see
+// isExplicitNamespaceList), otherwise the namespaces actually present in the backup,
+// discovered via the BackupResourceList download target.
+func BackupWorkloadNamespaces(ctx context.Context, clusterClient client.Client, backup velerov1.Backup, timeout time.Duration, skipTLS bool) ([]string, error) {
+	included := backup.Spec.IncludedNamespaces
+	if isExplicitNamespaceList(included, backup.Spec.ExcludedNamespaces) {
+		return included, nil
+	}
+
+	writeTo := &bytes.Buffer{}
+	if err := downloadrequest.Stream(ctx, clusterClient, backup.Namespace, backup.Name, velerov1.DownloadTargetKindBackupResourceList, writeTo, timeout, skipTLS, ""); err != nil {
+		return nil, err
+	}
+
+	resourceList := map[string][]string{}
+	if err := json.Unmarshal(writeTo.Bytes(), &resourceList); err != nil {
+		return nil, err
+	}
+	return namespacesFromResourceList(resourceList), nil
+}
+
+// RestoreWorkloadNamespaces returns the application namespaces a Restore actually
+// writes objects into: restore.Spec.IncludedNamespaces (remapped through
+// restore.Spec.NamespaceMapping) when it unambiguously names them (see
+// isExplicitNamespaceList), otherwise the namespaces actually restored into,
+// discovered via the RestoreResourceList download target.
+func RestoreWorkloadNamespaces(ctx context.Context, clusterClient client.Client, restore velerov1.Restore, timeout time.Duration, skipTLS bool) ([]string, error) {
+	included := restore.Spec.IncludedNamespaces
+	if isExplicitNamespaceList(included, restore.Spec.ExcludedNamespaces) {
+		namespaces := make([]string, 0, len(included))
+		for _, namespace := range included {
+			if target, ok := restore.Spec.NamespaceMapping[namespace]; ok {
+				namespaces = append(namespaces, target)
+			} else {
+				namespaces = append(namespaces, namespace)
+			}
+		}
+		return namespaces, nil
+	}
+
+	writeTo := &bytes.Buffer{}
+	if err := downloadrequest.Stream(ctx, clusterClient, restore.Namespace, restore.Name, velerov1.DownloadTargetKindRestoreResourceList, writeTo, timeout, skipTLS, ""); err != nil {
+		return nil, err
+	}
+
+	resourceList := map[string][]string{}
+	if err := json.Unmarshal(writeTo.Bytes(), &resourceList); err != nil {
+		return nil, err
+	}
+	return namespacesFromResourceList(resourceList), nil
+}

--- a/pkg/templates/summary.go
+++ b/pkg/templates/summary.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"slices"
+	"sort"
 	"strings"
 	"time"
 
@@ -53,6 +54,7 @@ var (
 		"VOLUME_SNAPSHOT_LOCATIONS",
 		"BACKUPS",
 		"RESTORES",
+		"WORKLOAD_NAMESPACES",
 		"SCHEDULES",
 		"BACKUPS_REPOSITORIES",
 		"DATA_UPLOADS",
@@ -93,6 +95,7 @@ const summaryTemplate = `# OADP must-gather summary version <<MUST_GATHER_VERSIO
     - [VolumeSnapshotLocations (VSLs)](#volumesnapshotlocations-vsls)
     - [Backups](#backups)
     - [Restores](#restores)
+    - [Workload namespaces (Backups/Restores)](#workload-namespaces-backupsrestores)
     - [Schedules](#schedules)
     - [BackupRepositories](#backuprepositories)
     - [DataUploads](#datauploads)
@@ -158,6 +161,15 @@ const summaryTemplate = `# OADP must-gather summary version <<MUST_GATHER_VERSIO
 ### Restores
 
 <<RESTORES>>
+
+### Workload namespaces (Backups/Restores)
+
+Application namespaces referenced by Backup/Restore spec.includedNamespaces (or
+discovered from the actual backed-up/restored resources when unset/"*"). These are
+also passed to oc adm inspect, so their PVC/PV/Namespace(SCC)/pod data is collected
+under namespaces/<namespace>/ alongside the OADP operator namespace.
+
+<<WORKLOAD_NAMESPACES>>
 
 ### Schedules
 
@@ -832,6 +844,28 @@ func ReplaceRestoresSection(
 		}
 	} else {
 		summaryTemplateReplaces["RESTORES"] = "❌ No Restore was found in the cluster"
+	}
+}
+
+func ReplaceWorkloadNamespacesSection(workloadNamespaces map[string][]string) {
+	if len(workloadNamespaces) != 0 {
+		namespaces := make([]string, 0, len(workloadNamespaces))
+		for namespace := range workloadNamespaces {
+			namespaces = append(namespaces, namespace)
+		}
+		sort.Strings(namespaces)
+
+		summaryTemplateReplaces["WORKLOAD_NAMESPACES"] = "| Namespace | Referenced by |\n| --- | --- |\n"
+		for _, namespace := range namespaces {
+			referencedBy := slices.Clone(workloadNamespaces[namespace])
+			sort.Strings(referencedBy)
+			summaryTemplateReplaces["WORKLOAD_NAMESPACES"] += fmt.Sprintf(
+				"| %v | %v |\n",
+				namespace, strings.Join(referencedBy, ", "),
+			)
+		}
+	} else {
+		summaryTemplateReplaces["WORKLOAD_NAMESPACES"] = "❌ No workload namespaces were discovered from Backup/Restore spec.includedNamespaces"
 	}
 }
 


### PR DESCRIPTION
> [!Note]
> Responses generated with Claude

## Summary

- `must-gather` only ran `oc adm inspect ns/<ns>` for namespaces where an OADP-related operator CSV is installed (e.g. `openshift-adp`). It never inspected the actual **application namespaces** a Backup/Restore operates on, so PVC/PV objects, the workload `Namespace` object (with its `openshift.io/sa.scc.uid-range` / `...supplemental-groups` annotations), pod specs, and events were missing from the bundle — blocking root-cause of restore permission/ownership bugs (restore reports `Completed` with no warnings, but files land with the wrong owner/mode).
- Extends the existing inspect call to also cover namespaces referenced by `Backup.spec.includedNamespaces` / `Restore.spec.includedNamespaces`, **only when that field unambiguously names them** — non-empty, no `excludedNamespaces`, no entry is the literal `"*"` or a glob pattern (`*`, `?`, `[...]`, which Velero's `pkg/util/wildcard` expands against the live namespace list at backup/restore time — see e.g. velero-io/velero#9772 for a further namespace-selection mechanism in design). In every other case, falls back to the namespaces actually present in the backup/restore, discovered via Velero's `BackupResourceList`/`RestoreResourceList` download targets (same `downloadrequest.Stream` helper already used elsewhere in this repo for backup/restore logs — no new RBAC). This fallback is what makes the feature correct regardless of which namespace-selection mechanism Velero uses, present or future.
- Restore-referenced namespaces are remapped through `spec.namespaceMapping` since that's where objects actually land.
- Adds a new "Workload namespaces (Backups/Restores)" table to `oadp-must-gather-summary.md` listing which namespaces were discovered and which namespace-qualified `Backup/<namespace>/<name>` / `Restore/<namespace>/<name>` referenced them (names are only unique per-namespace).
- This is Tier 1 from #149. Tier 2 (exec `mount`/`stat` on node-agent pods, needs new `pods/exec` RBAC) is intentionally out of scope here.

**Known trade-off:** `oc adm inspect ns/<namespace>` collects Secrets in that namespace, same as it already does today for the OADP operator namespace (see README.md). Expanding inspection to application namespaces referenced by Backup/Restore means their Secrets are now included in the bundle too. In practice this is narrower than it sounds: `oc adm inspect` elides Secret `.data` values (replacing each with a byte-length placeholder, except for known-public keys like `tls.crt`/`ca.crt`) before writing anything to disk — see [`elideSecret`](https://github.com/openshift/oc/blob/ae1bd9e4a75b8ab617a569e5c8e1a0d7285a16f6/pkg/cli/admin/inspect/secret.go#L62-L77), reached unconditionally for every `ns/<name>` target. No code in this repo touches Secret objects directly.

Errors from the workload-namespace lookup are logged as a static message rather than the wrapped error, since Velero `downloadrequest` failures can embed the backup storage location's raw HTTP response body (endpoint/bucket details) that must not end up in the must-gather pod's captured logs.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Manual: ran against a real OpenShift 4.22 cluster with OADP installed, covering all 4 explicit/fallback × Backup/Restore combinations (see comment below) — confirmed PVC/PV/Namespace(SCC)/pod data collected for each discovered namespace, and the summary table lists them correctly with namespace-qualified references.

Fixes #149


## Summary by CodeRabbit

* **New Features**
  * Must-gather inspection now also discovers and includes workload-associated namespaces referenced by backups and restores, including restore namespace mappings, with correct handling of glob patterns and excluded namespaces.
  * Must-gather summary reports now add a sorted **"Workload namespaces (Backups/Restores)"** section with referenced workloads per namespace.
* **Bug Fixes**
  * Namespace discovery/inspection failures for an individual backup or restore no longer stop the overall process; remaining items continue.
  * Inspection target namespaces are deduplicated for clearer, more accurate results.
