### PR TITLE
Remove inactive users from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,11 +1,8 @@
 approvers:
   - dymurray
-  - jmontleon
   - jwmatthews
   - kaovilai
   - mpryc
-  - mrnold
-  - rayfordj
   - shawn-hurley
   - shubham-pampattiwar
   - sseago
@@ -14,7 +11,6 @@ approvers:
 reviewers:
   - kaovilai
   - mpryc
-  - mrnold
   - shubham-pampattiwar
   - sseago
   - weshayutin


### PR DESCRIPTION
Remove inactive users from OWNERS approvers/reviewers.

---
@kaovilai requested in [Slack thread](https://redhat-internal.slack.com/archives/C0BHTAWB542/p1785509108887839)